### PR TITLE
A proposal for Bootstrap styling Patata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.phpintel

--- a/index.php
+++ b/index.php
@@ -62,8 +62,8 @@
             <div class="row">
                 <div class="col-md-6">
                     <div class="statswrapper">
-                        <h6>Recently added items:</h6>
-                        <table class="table table-striped table-sm ">
+                        <h6 class="text-center">Recently added items</h6>
+                        <table class="table table-striped table-sm text-center">
                             <thead>
                                 <tr>
                                     <td>Item</td>
@@ -118,8 +118,8 @@
 
                 <div class="col-md-6">
                     <div class="statswrapper">
-                        <h6>Recently modified items:</h6>
-                        <table class="table table-striped table-sm ">
+                        <h6 class="text-center">Recently modified items</h6>
+                        <table class="table table-striped table-sm text-center">
                             <thead>
                                 <tr>
                                     <td>Item</td>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,23 @@
 <!DOCTYPE html>
 <html>
-<body onload="display_ct(), display_qt()">
+    <head>
+        <link rel="stylesheet" type="text/css" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" />
+        <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
+    </head>
+    <body onload="display_ct(), display_qt()">
+        <div class="container">
+            <h1>Patata</h1>
+
+            <div class="row">
+                <div class="col-md-6">      
+                    <div id='ct'></div>
+                    <div id='ct2'></div>
+                </div>
+                <div class="col-md-6">
+                    <div align=right id='quotesbox'></div>
+                    <div align=right id='authorbox'></div>
+                </div>
+            </div>
 
 <?php
 $taskin = file_get_contents("task.json");
@@ -11,44 +28,6 @@ $obj2 = json_decode("$quotesin", TRUE);
 
 $num_quotes = count($obj2) - 1;
 $quote_refresh = 5; // In seconds
-
-echo "<script type=\"text/javascript\"> 
-function display_c(){
-var refresh=1000;
-mytime=setTimeout('display_ct()',refresh)
-}
-
-function addZero(i) {
-    if (i < 10) {
-        i = \"0\" + i;
-    }
-    return i;
-}
-
-function display_ct() {
-
-    var months = [\"January\", \"February\", \"March\", \"April\", \"May\", \"June\", \"July\", \"August\", \"September\", \"October\", \"November\", \"December\"];
-    var x = new Date()
-    var d = addZero(x.getDate())
-    var mo = months[x.getMonth()]
-    var y = addZero(x.getFullYear())
-    var h = addZero(x.getHours())
-    var mi = addZero(x.getMinutes())
-    var s = addZero(x.getSeconds())
-    var wd = [\"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\"]
-    var td = wd[x.getDay()]
-    var x1 = td + \" - \" + d + \" \" + mo + \" \" + y
-    var x2 = h + \":\" + mi + \":\" + s
-    document.getElementById('ct').innerHTML = x1
-    document.getElementById('ct2').innerHTML = x2
-    
-    display_c();
-}
-
-</script>
-
-<div id='ct'></div>
-<div id='ct2'></div>";
 
 echo "<script type=\"text/javascript\"> 
 function display_q(){
@@ -66,10 +45,7 @@ function display_qt() {
     display_q();
 }
 
-</script>
-
-<div align=right id='quotesbox'></div>
-<div align=right id='authorbox'></div>";
+</script>";
 
 echo "<div class=\"task\">
     <table style=\"width:70%\" align=\"center\">";
@@ -207,5 +183,39 @@ echo "<div align=right class=\"statswrapper\">
     <div>";
 ?>
 
-</body>
+        </div>
+
+        <script type="text/javascript"> 
+            function display_c(){
+                var refresh=1000;
+                mytime=setTimeout('display_ct()',refresh)
+            }
+
+            function addZero(i) {
+                if (i < 10) {
+                    i = "0" + i;
+                }
+                return i;
+            }
+
+            function display_ct() {
+                var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+                var x = new Date()
+                var d = addZero(x.getDate())
+                var mo = months[x.getMonth()]
+                var y = addZero(x.getFullYear())
+                var h = addZero(x.getHours())
+                var mi = addZero(x.getMinutes())
+                var s = addZero(x.getSeconds())
+                var wd = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+                var td = wd[x.getDay()]
+                var x1 = td + " - " + d + " " + mo + " " + y
+                var x2 = h + ":" + mi + ":" + s
+                document.getElementById('ct').innerHTML = x1
+                document.getElementById('ct2').innerHTML = x2
+
+                display_c();
+            }
+        </script>
+    </body>
 </html> 

--- a/index.php
+++ b/index.php
@@ -19,61 +19,43 @@
                 </div>
             </div>
 
+            <hr/>
+            
+            <div class="task mt-5">
+                <h4 class="text-center">Tasklist</h4>
+                <table class="table" style="width: 70%; margin: 0 auto;">
+                    <tr>
+                        <th>ID</th>
+                        <th>Priority</th>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>Maintainer</th>
+                    </tr>
+                    <?php
+                        $taskin = file_get_contents("task.json");
+                        $obj = json_decode("$taskin", TRUE);
+
+                        foreach ($obj as $tasklist) {
+                            if (!$tasklist['done']) {
+                                echo "<tr>";
+                                echo "<td>".$tasklist['id']."</td>";
+                                echo "<td>".$tasklist['priority']."</td>";
+                                echo "<td>".$tasklist['title']."</td>";
+                                echo "<td>";
+                                echo isset($tasklist['message']) ? $tasklist['message']: "";
+                                echo "</td>";
+                                echo "<td>".implode(", ", $tasklist['maintainer'])."</td>";
+                                //echo "<td>".$tasklist['done']."</td>";
+                                echo "</tr>";
+                            }
+                        }
+                    ?>
+                </table> 
+            </div>
+
+            <hr/>
+
 <?php
-$taskin = file_get_contents("task.json");
-$quotesin = file_get_contents("quotes.json");
-
-$obj = json_decode("$taskin", TRUE);
-$obj2 = json_decode("$quotesin", TRUE);
-
-$num_quotes = count($obj2) - 1;
-$quote_refresh = 5; // In seconds
-
-echo "<script type=\"text/javascript\"> 
-function display_q(){
-    var refresh=1000*$quote_refresh;
-    mytime=setTimeout('display_qt()',refresh)
-}
-
-function display_qt() {
-
-    var quotes_array = $quotesin
-    var val = Math.floor(Math.random() * $num_quotes)
-    document.getElementById('quotesbox').innerHTML = quotes_array[val].quote
-    document.getElementById('authorbox').innerHTML = \"Cit. \" + quotes_array[val].author
-
-    display_q();
-}
-
-</script>";
-
-echo "<div class=\"task\">
-    <table style=\"width:70%\" align=\"center\">";
-echo "<tr>
-    <th>ID</th>
-    <th>Priority</th>
-    <th>Title</th>
-    <th>Description</th>
-    <th>Maintainer</th>
-    </tr>";
-
-foreach($obj as $tasklist){
-    
-    if(!$tasklist['done']){
-        echo "<tr>";
-        echo "<td>".$tasklist['id']."</td>";
-        echo "<td>".$tasklist['priority']."</td>";
-        echo "<td>".$tasklist['title']."</td>";
-        echo "<td>";
-        echo isset($tasklist['message']) ? $tasklist['message']: "";
-        echo "</td>";
-        echo "<td>".implode(", ", $tasklist['maintainer'])."</td>";
-        //echo "<td>".$tasklist['done']."</td>";
-        echo "</tr>";
-    }
-}
-echo "<br></table></div>";
-
 echo "<div class=\"statswrapper\">
 <p>Recently added items:</p>
 <table style=\"width:30%\">
@@ -216,6 +198,29 @@ echo "<div align=right class=\"statswrapper\">
 
                 display_c();
             }
+
+            <?php
+                $quotesin = file_get_contents("quotes.json");
+                $obj2 = json_decode("$quotesin", TRUE);
+                $num_quotes = count($obj2) - 1;
+                $quote_refresh = 5; // In seconds
+
+                echo "
+                function display_q(){
+                    var refresh=1000*$quote_refresh;
+                    mytime=setTimeout('display_qt()',refresh)
+                }
+
+                function display_qt() {
+
+                    var quotes_array = $quotesin
+                    var val = Math.floor(Math.random() * $num_quotes)
+                    document.getElementById('quotesbox').innerHTML = quotes_array[val].quote
+                    document.getElementById('authorbox').innerHTML = \"Cit. \" + quotes_array[val].author
+
+                    display_q();
+                }";
+            ?>
         </script>
     </body>
 </html> 

--- a/index.php
+++ b/index.php
@@ -20,151 +20,158 @@
             </div>
 
             <hr/>
-            
-            <div class="task mt-5">
-                <h4 class="text-center">Tasklist</h4>
-                <table class="table" style="width: 70%; margin: 0 auto;">
-                    <tr>
-                        <th>ID</th>
-                        <th>Priority</th>
-                        <th>Title</th>
-                        <th>Description</th>
-                        <th>Maintainer</th>
-                    </tr>
-                    <?php
-                        $taskin = file_get_contents("task.json");
-                        $obj = json_decode("$taskin", TRUE);
 
-                        foreach ($obj as $tasklist) {
-                            if (!$tasklist['done']) {
-                                echo "<tr>";
-                                echo "<td>".$tasklist['id']."</td>";
-                                echo "<td>".$tasklist['priority']."</td>";
-                                echo "<td>".$tasklist['title']."</td>";
-                                echo "<td>";
-                                echo isset($tasklist['message']) ? $tasklist['message']: "";
-                                echo "</td>";
-                                echo "<td>".implode(", ", $tasklist['maintainer'])."</td>";
-                                //echo "<td>".$tasklist['done']."</td>";
-                                echo "</tr>";
+            <div class="task">
+                <h5 class="text-center">Tasklist</h5>
+                <table class="table table-striped " style="width: 70%; margin: 0 auto;">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Priority</th>
+                            <th>Title</th>
+                            <th>Description</th>
+                            <th>Maintainer</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php
+                            $taskin = file_get_contents("task.json");
+                            $obj = json_decode("$taskin", TRUE);
+
+                            foreach ($obj as $tasklist) {
+                                if (!$tasklist['done']) {
+                                    echo "<tr>";
+                                    echo "<td>".$tasklist['id']."</td>";
+                                    echo "<td>".$tasklist['priority']."</td>";
+                                    echo "<td>".$tasklist['title']."</td>";
+                                    echo "<td>";
+                                    echo isset($tasklist['message']) ? $tasklist['message']: "";
+                                    echo "</td>";
+                                    echo "<td>".implode(", ", $tasklist['maintainer'])."</td>";
+                                    //echo "<td>".$tasklist['done']."</td>";
+                                    echo "</tr>";
+                                }
                             }
-                        }
-                    ?>
+                        ?>
+                    </tbody>
                 </table> 
             </div>
 
             <hr/>
 
-<?php
-echo "<div class=\"statswrapper\">
-<p>Recently added items:</p>
-<table style=\"width:30%\">
-    <thead>
-    <tr>
-        <td>Item</td>
-        <td>Added</td>
-    </tr>
-    </thead>
-    <tbody>
-                    <tr>
-            <td><a href=\"/item/R374\">R374</a></td>
-            <td>2018-10-18, 20:01</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/R373\">R373</a></td>
-            <td>2018-10-18, 20:01</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/C165\">C165</a></td>
-            <td>2018-10-18, 20:01</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/B152\">B152</a></td>
-            <td>2018-10-18, 20:01</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/R372\">R372</a></td>
-            <td>2018-10-18, 13:20</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/R371\">R371</a></td>
-            <td>2018-10-18, 13:20</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/127\">127</a></td>
-            <td>2018-10-16, 19:37</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/126\">126</a></td>
-            <td>2018-10-16, 19:16</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/HDD228\">HDD228</a></td>
-            <td>2018-10-16, 19:07</td>
-        </tr>
-                    <tr>
-            <td><a href=\"/item/HDD227\">HDD227</a></td>
-            <td>2018-10-16, 19:04</td>
-        </tr>
-    </tbody>
-<table>
-</div></tr></td>";
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="statswrapper">
+                        <h6>Recently added items:</h6>
+                        <table class="table table-striped table-sm ">
+                            <thead>
+                                <tr>
+                                    <td>Item</td>
+                                    <td>Added</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><a href="/item/R374">R374</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R373">R373</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/C165">C165</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/B152">B152</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R372">R372</a></td>
+                                    <td>2018-10-18, 13:20</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R371">R371</a></td>
+                                    <td>2018-10-18, 13:20</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/127">127</a></td>
+                                    <td>2018-10-16, 19:37</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/126">126</a></td>
+                                    <td>2018-10-16, 19:16</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/HDD228">HDD228</a></td>
+                                    <td>2018-10-16, 19:07</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/HDD227">HDD227</a></td>
+                                    <td>2018-10-16, 19:04</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
 
-echo "<div align=right class=\"statswrapper\">
-<p>Recently modified items:</p>
-<table align=right style=\"width:30%\">
-	<thead>
-	<tr>
-		<td>Item</td>
-		<td>Modified</td>
-	</tr>
-	</thead>
-	<tbody>
-					<tr>
-			<td><a href=\"/item/R374\">R374</a></td>
-			<td>2018-10-18, 20:01</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/R373\">R373</a></td>
-			<td>2018-10-18, 20:01</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/C165\">C165</a></td>
-			<td>2018-10-18, 20:01</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/B152\">B152</a></td>
-			<td>2018-10-18, 20:01</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/R372\">R372</a></td>
-			<td>2018-10-18, 13:20</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/R371\">R371</a></td>
-			<td>2018-10-18, 13:20</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/127\">127</a></td>
-			<td>2018-10-16, 19:37</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/126\">126</a></td>
-			<td>2018-10-16, 19:16</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/HDD228\">HDD228</a></td>
-			<td>2018-10-16, 19:07</td>
-		</tr>
-					<tr>
-			<td><a href=\"/item/HDD227\">HDD227</a></td>
-			<td>2018-10-16, 19:04</td>
-		</tr>
-				</tbody>
-	</table>
-    <div>";
-?>
-
+                <div class="col-md-6">
+                    <div class="statswrapper">
+                        <h6>Recently modified items:</h6>
+                        <table class="table table-striped table-sm ">
+                            <thead>
+                                <tr>
+                                    <td>Item</td>
+                                    <td>Modified</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><a href="/item/R374">R374</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R373">R373</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/C165">C165</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/B152">B152</a></td>
+                                    <td>2018-10-18, 20:01</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R372">R372</a></td>
+                                    <td>2018-10-18, 13:20</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/R371">R371</a></td>
+                                    <td>2018-10-18, 13:20</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/127">127</a></td>
+                                    <td>2018-10-16, 19:37</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/126">126</a></td>
+                                    <td>2018-10-16, 19:16</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/HDD228">HDD228</a></td>
+                                    <td>2018-10-16, 19:07</td>
+                                </tr>
+                                <tr>
+                                    <td><a href="/item/HDD227">HDD227</a></td>
+                                    <td>2018-10-16, 19:04</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    <div>
+                </div>
+            </div>
         </div>
 
         <script type="text/javascript"> 


### PR DESCRIPTION
This pull request submits a small proposal for a basic Bootstrap template in order to make *patata* look better. It uses Bootstrap's row-column structure to organize a grid, and Bootstrap's table classes to improve readability of the included tables.

I aimed to provide a basic, organized template to make *patata* look well and be well coded, in order to make it easier for it to be updated in the future. I didn't use any colors or images because I don't know if *patata* has/will have any design choices.

Here is a screenshot of *patata* before the changes:
![before](https://user-images.githubusercontent.com/26191851/47273068-479d5180-d55c-11e8-9e92-29abf08447a2.png)

Here is a screenshot of *patata* after the changes, on my local environment:
![after](https://user-images.githubusercontent.com/26191851/47273069-5421aa00-d55c-11e8-96d5-8ded266d08c4.png)

I fixed the two recently added/modified lists alignment.

Note that Bootstrap files are being pulled from a CDN; if *patata* is going to be used in an offline environment, it can easily be changed to use offline files.

Let me know if I can fix anything else here!

Pull request submitted as a fix for issue #2 
